### PR TITLE
Remove unused attributes, RadioID API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,6 @@ In the case of analog FM zone names, all repeaters go into the specified zone, s
     	Radius for proximity search (default 25)
   -tg
     	Only include DMR repeaters that have talkgroups defined (default true)
-  -tg_source string
-    	One of ('most' 'rfinder' 'details').
-    	RadioID has two fields that may contain talkgroup info, 'details' and 'rfinder'.
-    	By default dmrfill uses the data from whichever field has the most talkgroups defined.
-    	Selecting 'rfinder' or 'details' uses the named field. (default "most")
   -units string
     	Distance units for proximity search, one of ('miles' 'km') (default "miles")
   -v	verbose logging

--- a/codeplug.go
+++ b/codeplug.go
@@ -10,227 +10,227 @@ import (
 type Codeplug struct {
 	Version  string `yaml:"version"`
 	Settings struct {
-		IntroLine1 string `yaml:"introLine1"`
-		IntroLine2 string `yaml:"introLine2"`
-		MicLevel   int    `yaml:"micLevel"`
-		Speech     bool   `yaml:"speech"`
-		Power      string `yaml:"power"`
-		Squelch    int    `yaml:"squelch"`
-		Vox        int    `yaml:"vox"`
-		Tot        int    `yaml:"tot"`
-		Anytone    struct {
-			SubChannel             bool   `yaml:"subChannel"`
-			SelectedVFO            string `yaml:"selectedVFO"`
-			ModeA                  string `yaml:"modeA"`
-			ModeB                  string `yaml:"modeB"`
-			VfoScanType            string `yaml:"vfoScanType"`
-			MinVFOScanFrequencyUHF string `yaml:"minVFOScanFrequencyUHF"`
-			MaxVFOScanFrequencyUHF string `yaml:"maxVFOScanFrequencyUHF"`
-			MinVFOScanFrequencyVHF string `yaml:"minVFOScanFrequencyVHF"`
-			MaxVFOScanFrequencyVHF string `yaml:"maxVFOScanFrequencyVHF"`
-			KeepLastCaller         bool   `yaml:"keepLastCaller"`
-			VfoStep                string `yaml:"vfoStep"`
-			SteType                string `yaml:"steType"`
-			SteFrequency           int    `yaml:"steFrequency"`
-			SteDuration            string `yaml:"steDuration"`
-			TbstFrequency          string `yaml:"tbstFrequency"`
-			ProMode                bool   `yaml:"proMode"`
-			MaintainCallChannel    bool   `yaml:"maintainCallChannel"`
-			BootSettings           struct {
-				BootDisplay         string                 `yaml:"bootDisplay"`
-				BootPasswordEnabled bool                   `yaml:"bootPasswordEnabled"`
-				BootPassword        string                 `yaml:"bootPassword"`
-				DefaultChannel      bool                   `yaml:"defaultChannel"`
-				GpsCheck            bool                   `yaml:"gpsCheck"`
-				Reset               bool                   `yaml:"reset"`
-				Additional          map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"bootSettings"`
-			PowerSaveSettings struct {
-				AutoShutdown            int                    `yaml:"autoShutdown"`
-				ResetAutoShutdownOnCall bool                   `yaml:"resetAutoShutdownOnCall"`
-				PowerSave               string                 `yaml:"powerSave"`
-				Atpc                    bool                   `yaml:"atpc"`
-				Additional              map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"powerSaveSettings"`
-			KeySettings struct {
-				FuncKey1Short     string                 `yaml:"funcKey1Short"`
-				FuncKey1Long      string                 `yaml:"funcKey1Long"`
-				FuncKey2Short     string                 `yaml:"funcKey2Short"`
-				FuncKey2Long      string                 `yaml:"funcKey2Long"`
-				FuncKey3Short     string                 `yaml:"funcKey3Short"`
-				FuncKey3Long      string                 `yaml:"funcKey3Long"`
-				FuncKey4Short     string                 `yaml:"funcKey4Short"`
-				FuncKey4Long      string                 `yaml:"funcKey4Long"`
-				FuncKey5Short     string                 `yaml:"funcKey5Short"`
-				FuncKey5Long      string                 `yaml:"funcKey5Long"`
-				FuncKey6Short     string                 `yaml:"funcKey6Short"`
-				FuncKey6Long      string                 `yaml:"funcKey6Long"`
-				FuncKeyAShort     string                 `yaml:"funcKeyAShort"`
-				FuncKeyALong      string                 `yaml:"funcKeyALong"`
-				FuncKeyBShort     string                 `yaml:"funcKeyBShort"`
-				FuncKeyBLong      string                 `yaml:"funcKeyBLong"`
-				FuncKeyCShort     string                 `yaml:"funcKeyCShort"`
-				FuncKeyCLong      string                 `yaml:"funcKeyCLong"`
-				FuncKeyDShort     string                 `yaml:"funcKeyDShort"`
-				FuncKeyDLong      string                 `yaml:"funcKeyDLong"`
-				LongPressDuration string                 `yaml:"longPressDuration"`
-				AutoKeyLock       bool                   `yaml:"autoKeyLock"`
-				KnobLock          bool                   `yaml:"knobLock"`
-				KeypadLock        bool                   `yaml:"keypadLock"`
-				SideKeysLock      bool                   `yaml:"sideKeysLock"`
-				ForcedKeyLock     bool                   `yaml:"forcedKeyLock"`
-				Additional        map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"keySettings"`
-			ToneSettings struct {
-				KeyTone       bool `yaml:"keyTone"`
-				KeyToneLevel  int  `yaml:"keyToneLevel"`
-				SmsAlert      bool `yaml:"smsAlert"`
-				CallAlert     bool `yaml:"callAlert"`
-				DmrTalkPermit bool `yaml:"dmrTalkPermit"`
-				DmrReset      bool `yaml:"dmrReset"`
-				FmTalkPermit  bool `yaml:"fmTalkPermit"`
-				DmrIdle       bool `yaml:"dmrIdle"`
-				FmIdle        bool `yaml:"fmIdle"`
-				Startup       bool `yaml:"startup"`
-				Tot           bool `yaml:"tot"`
-				CallMelody    struct {
-					Bpm        int                    `yaml:"bpm"`
-					Melody     string                 `yaml:"melody"`
-					Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-				} `yaml:"callMelody"`
-				IdleMelody struct {
-					Bpm        int                    `yaml:"bpm"`
-					Melody     string                 `yaml:"melody"`
-					Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-				} `yaml:"idleMelody"`
-				ResetMelody struct {
-					Bpm        int                    `yaml:"bpm"`
-					Melody     string                 `yaml:"melody"`
-					Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-				} `yaml:"resetMelody"`
-				CallEndMelody struct {
-					Bpm        int                    `yaml:"bpm"`
-					Melody     string                 `yaml:"melody"`
-					Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-				} `yaml:"callEndMelody"`
-				Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"toneSettings"`
-			DisplaySettings struct {
-				DisplayFrequency        bool                   `yaml:"displayFrequency"`
-				Brightness              int                    `yaml:"brightness"`
-				BacklightDuration       int                    `yaml:"backlightDuration"`
-				BacklightDurationTX     int                    `yaml:"backlightDurationTX"`
-				BacklightDurationRX     int                    `yaml:"backlightDurationRX"`
-				CustomChannelBackground bool                   `yaml:"customChannelBackground"`
-				VolumeChangePrompt      bool                   `yaml:"volumeChangePrompt"`
-				CallEndPrompt           bool                   `yaml:"callEndPrompt"`
-				ShowClock               bool                   `yaml:"showClock"`
-				ShowCall                bool                   `yaml:"showCall"`
-				ShowContact             bool                   `yaml:"showContact"`
-				ShowChannelNumber       bool                   `yaml:"showChannelNumber"`
-				ShowColorCode           bool                   `yaml:"showColorCode"`
-				ShowTimeSlot            bool                   `yaml:"showTimeSlot"`
-				ShowChannelType         bool                   `yaml:"showChannelType"`
-				ShowLastHeard           bool                   `yaml:"showLastHeard"`
-				LastCallerDisplay       string                 `yaml:"lastCallerDisplay"`
-				CallColor               string                 `yaml:"callColor"`
-				StandbyTextColor        string                 `yaml:"standbyTextColor"`
-				StandbyBackgroundColor  string                 `yaml:"standbyBackgroundColor"`
-				ChannelNameColor        string                 `yaml:"channelNameColor"`
-				ChannelBNameColor       string                 `yaml:"channelBNameColor"`
-				ZoneNameColor           string                 `yaml:"zoneNameColor"`
-				ZoneBNameColor          string                 `yaml:"zoneBNameColor"`
-				Language                string                 `yaml:"language"`
-				DateFormat              string                 `yaml:"dateFormat"`
-				Additional              map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"displaySettings"`
-			AudioSettings struct {
-				VoxDelay           string                 `yaml:"voxDelay"`
-				VoxSource          string                 `yaml:"voxSource"`
-				Recording          bool                   `yaml:"recording"`
-				Enhance            bool                   `yaml:"enhance"`
-				MuteDelay          string                 `yaml:"muteDelay"`
-				MaxVolume          int                    `yaml:"maxVolume"`
-				MaxHeadPhoneVolume int                    `yaml:"maxHeadPhoneVolume"`
-				EnableFMMicGain    bool                   `yaml:"enableFMMicGain"`
-				FmMicGain          int                    `yaml:"fmMicGain"`
-				Additional         map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"audioSettings"`
-			MenuSettings struct {
-				Duration   string                 `yaml:"duration"`
-				Separator  bool                   `yaml:"separator"`
-				Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"menuSettings"`
-			AutoRepeaterSettings struct {
-				DirectionA string                 `yaml:"directionA"`
-				DirectionB string                 `yaml:"directionB"`
-				VhfMin     string                 `yaml:"vhfMin"`
-				VhfMax     string                 `yaml:"vhfMax"`
-				UhfMin     string                 `yaml:"uhfMin"`
-				UhfMax     string                 `yaml:"uhfMax"`
-				Vhf2Min    string                 `yaml:"vhf2Min"`
-				Vhf2Max    string                 `yaml:"vhf2Max"`
-				Uhf2Min    string                 `yaml:"uhf2Min"`
-				Uhf2Max    string                 `yaml:"uhf2Max"`
-				Offsets    []interface{}          `yaml:"offsets"`
-				Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"autoRepeaterSettings"`
-			DmrSettings struct {
-				GroupCallHangTime         string                 `yaml:"groupCallHangTime"`
-				ManualGroupCallHangTime   string                 `yaml:"manualGroupCallHangTime"`
-				PrivateCallHangTime       string                 `yaml:"privateCallHangTime"`
-				ManualPrivateCallHangTime string                 `yaml:"manualPrivateCallHangTime"`
-				PreWaveDelay              int                    `yaml:"preWaveDelay"`
-				WakeHeadPeriod            int                    `yaml:"wakeHeadPeriod"`
-				FilterOwnID               bool                   `yaml:"filterOwnID"`
-				MonitorSlotMatch          string                 `yaml:"monitorSlotMatch"`
-				MonitorColorCodeMatch     bool                   `yaml:"monitorColorCodeMatch"`
-				MonitorIDMatch            bool                   `yaml:"monitorIDMatch"`
-				MonitorTimeSlotHold       bool                   `yaml:"monitorTimeSlotHold"`
-				SmsFormat                 string                 `yaml:"smsFormat"`
-				SendTalkerAlias           bool                   `yaml:"sendTalkerAlias"`
-				TalkerAliasSource         string                 `yaml:"talkerAliasSource"`
-				TalkerAliasEncoding       string                 `yaml:"talkerAliasEncoding"`
-				Encryption                string                 `yaml:"encryption"`
-				Additional                map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"dmrSettings"`
-			GpsSettings struct {
-				Units          string                 `yaml:"units"`
-				TimeZone       string                 `yaml:"timeZone"`
-				ReportPosition bool                   `yaml:"reportPosition"`
-				UpdatePeriod   string                 `yaml:"updatePeriod"`
-				Mode           string                 `yaml:"mode"`
-				Additional     map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"gpsSettings"`
-			RoamingSettings struct {
-				AutoRoam          bool                   `yaml:"autoRoam"`
-				AutoRoamPeriod    string                 `yaml:"autoRoamPeriod"`
-				AutoRoamDelay     int                    `yaml:"autoRoamDelay"`
-				RoamStart         string                 `yaml:"roamStart"`
-				RoamReturn        string                 `yaml:"roamReturn"`
-				RangeCheck        bool                   `yaml:"rangeCheck"`
-				CheckInterval     string                 `yaml:"checkInterval"`
-				RetryCount        int                    `yaml:"retryCount"`
-				OutOfRangeAlert   string                 `yaml:"outOfRangeAlert"`
-				Notification      bool                   `yaml:"notification"`
-				NotificationCount int                    `yaml:"notificationCount"`
-				GpsRoaming        bool                   `yaml:"gpsRoaming"`
-				Additional        map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"roamingSettings"`
-			BluetoothSettings struct {
-				PttLatch      bool                   `yaml:"pttLatch"`
-				PttSleepTimer int                    `yaml:"pttSleepTimer"`
-				Additional    map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"bluetoothSettings"`
-			SimplexRepeaterSettings struct {
-				Enabled    bool                   `yaml:"enabled"`
-				Monitor    bool                   `yaml:"monitor"`
-				TimeSlot   string                 `yaml:"timeSlot"`
-				Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"simplexRepeaterSettings"`
-			Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-		} `yaml:"anytone,omitempty"`
-		DefaultID  string                 `yaml:"defaultID,omitempty"`
+		// IntroLine1 string `yaml:"introLine1"`
+		// IntroLine2 string `yaml:"introLine2"`
+		// MicLevel   int    `yaml:"micLevel"`
+		// Speech     bool   `yaml:"speech"`
+		// Power      string `yaml:"power"`
+		// Squelch    int    `yaml:"squelch"`
+		// Vox        int    `yaml:"vox"`
+		// Tot        int    `yaml:"tot"`
+		// Anytone    struct {
+		// 	SubChannel             bool   `yaml:"subChannel"`
+		// 	SelectedVFO            string `yaml:"selectedVFO"`
+		// 	ModeA                  string `yaml:"modeA"`
+		// 	ModeB                  string `yaml:"modeB"`
+		// 	VfoScanType            string `yaml:"vfoScanType"`
+		// 	MinVFOScanFrequencyUHF string `yaml:"minVFOScanFrequencyUHF"`
+		// 	MaxVFOScanFrequencyUHF string `yaml:"maxVFOScanFrequencyUHF"`
+		// 	MinVFOScanFrequencyVHF string `yaml:"minVFOScanFrequencyVHF"`
+		// 	MaxVFOScanFrequencyVHF string `yaml:"maxVFOScanFrequencyVHF"`
+		// 	KeepLastCaller         bool   `yaml:"keepLastCaller"`
+		// 	VfoStep                string `yaml:"vfoStep"`
+		// 	SteType                string `yaml:"steType"`
+		// 	SteFrequency           int    `yaml:"steFrequency"`
+		// 	SteDuration            string `yaml:"steDuration"`
+		// 	TbstFrequency          string `yaml:"tbstFrequency"`
+		// 	ProMode                bool   `yaml:"proMode"`
+		// 	MaintainCallChannel    bool   `yaml:"maintainCallChannel"`
+		// 	BootSettings           struct {
+		// 		BootDisplay         string                 `yaml:"bootDisplay"`
+		// 		BootPasswordEnabled bool                   `yaml:"bootPasswordEnabled"`
+		// 		BootPassword        string                 `yaml:"bootPassword"`
+		// 		DefaultChannel      bool                   `yaml:"defaultChannel"`
+		// 		GpsCheck            bool                   `yaml:"gpsCheck"`
+		// 		Reset               bool                   `yaml:"reset"`
+		// 		Additional          map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"bootSettings"`
+		// 	PowerSaveSettings struct {
+		// 		AutoShutdown            int                    `yaml:"autoShutdown"`
+		// 		ResetAutoShutdownOnCall bool                   `yaml:"resetAutoShutdownOnCall"`
+		// 		PowerSave               string                 `yaml:"powerSave"`
+		// 		Atpc                    bool                   `yaml:"atpc"`
+		// 		Additional              map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"powerSaveSettings"`
+		// 	KeySettings struct {
+		// 		FuncKey1Short     string                 `yaml:"funcKey1Short"`
+		// 		FuncKey1Long      string                 `yaml:"funcKey1Long"`
+		// 		FuncKey2Short     string                 `yaml:"funcKey2Short"`
+		// 		FuncKey2Long      string                 `yaml:"funcKey2Long"`
+		// 		FuncKey3Short     string                 `yaml:"funcKey3Short"`
+		// 		FuncKey3Long      string                 `yaml:"funcKey3Long"`
+		// 		FuncKey4Short     string                 `yaml:"funcKey4Short"`
+		// 		FuncKey4Long      string                 `yaml:"funcKey4Long"`
+		// 		FuncKey5Short     string                 `yaml:"funcKey5Short"`
+		// 		FuncKey5Long      string                 `yaml:"funcKey5Long"`
+		// 		FuncKey6Short     string                 `yaml:"funcKey6Short"`
+		// 		FuncKey6Long      string                 `yaml:"funcKey6Long"`
+		// 		FuncKeyAShort     string                 `yaml:"funcKeyAShort"`
+		// 		FuncKeyALong      string                 `yaml:"funcKeyALong"`
+		// 		FuncKeyBShort     string                 `yaml:"funcKeyBShort"`
+		// 		FuncKeyBLong      string                 `yaml:"funcKeyBLong"`
+		// 		FuncKeyCShort     string                 `yaml:"funcKeyCShort"`
+		// 		FuncKeyCLong      string                 `yaml:"funcKeyCLong"`
+		// 		FuncKeyDShort     string                 `yaml:"funcKeyDShort"`
+		// 		FuncKeyDLong      string                 `yaml:"funcKeyDLong"`
+		// 		LongPressDuration string                 `yaml:"longPressDuration"`
+		// 		AutoKeyLock       bool                   `yaml:"autoKeyLock"`
+		// 		KnobLock          bool                   `yaml:"knobLock"`
+		// 		KeypadLock        bool                   `yaml:"keypadLock"`
+		// 		SideKeysLock      bool                   `yaml:"sideKeysLock"`
+		// 		ForcedKeyLock     bool                   `yaml:"forcedKeyLock"`
+		// 		Additional        map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"keySettings"`
+		// 	ToneSettings struct {
+		// 		KeyTone       bool `yaml:"keyTone"`
+		// 		KeyToneLevel  int  `yaml:"keyToneLevel"`
+		// 		SmsAlert      bool `yaml:"smsAlert"`
+		// 		CallAlert     bool `yaml:"callAlert"`
+		// 		DmrTalkPermit bool `yaml:"dmrTalkPermit"`
+		// 		DmrReset      bool `yaml:"dmrReset"`
+		// 		FmTalkPermit  bool `yaml:"fmTalkPermit"`
+		// 		DmrIdle       bool `yaml:"dmrIdle"`
+		// 		FmIdle        bool `yaml:"fmIdle"`
+		// 		Startup       bool `yaml:"startup"`
+		// 		Tot           bool `yaml:"tot"`
+		// 		CallMelody    struct {
+		// 			Bpm        int                    `yaml:"bpm"`
+		// 			Melody     string                 `yaml:"melody"`
+		// 			Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 		} `yaml:"callMelody"`
+		// 		IdleMelody struct {
+		// 			Bpm        int                    `yaml:"bpm"`
+		// 			Melody     string                 `yaml:"melody"`
+		// 			Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 		} `yaml:"idleMelody"`
+		// 		ResetMelody struct {
+		// 			Bpm        int                    `yaml:"bpm"`
+		// 			Melody     string                 `yaml:"melody"`
+		// 			Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 		} `yaml:"resetMelody"`
+		// 		CallEndMelody struct {
+		// 			Bpm        int                    `yaml:"bpm"`
+		// 			Melody     string                 `yaml:"melody"`
+		// 			Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 		} `yaml:"callEndMelody"`
+		// 		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"toneSettings"`
+		// 	DisplaySettings struct {
+		// 		DisplayFrequency        bool                   `yaml:"displayFrequency"`
+		// 		Brightness              int                    `yaml:"brightness"`
+		// 		BacklightDuration       int                    `yaml:"backlightDuration"`
+		// 		BacklightDurationTX     int                    `yaml:"backlightDurationTX"`
+		// 		BacklightDurationRX     int                    `yaml:"backlightDurationRX"`
+		// 		CustomChannelBackground bool                   `yaml:"customChannelBackground"`
+		// 		VolumeChangePrompt      bool                   `yaml:"volumeChangePrompt"`
+		// 		CallEndPrompt           bool                   `yaml:"callEndPrompt"`
+		// 		ShowClock               bool                   `yaml:"showClock"`
+		// 		ShowCall                bool                   `yaml:"showCall"`
+		// 		ShowContact             bool                   `yaml:"showContact"`
+		// 		ShowChannelNumber       bool                   `yaml:"showChannelNumber"`
+		// 		ShowColorCode           bool                   `yaml:"showColorCode"`
+		// 		ShowTimeSlot            bool                   `yaml:"showTimeSlot"`
+		// 		ShowChannelType         bool                   `yaml:"showChannelType"`
+		// 		ShowLastHeard           bool                   `yaml:"showLastHeard"`
+		// 		LastCallerDisplay       string                 `yaml:"lastCallerDisplay"`
+		// 		CallColor               string                 `yaml:"callColor"`
+		// 		StandbyTextColor        string                 `yaml:"standbyTextColor"`
+		// 		StandbyBackgroundColor  string                 `yaml:"standbyBackgroundColor"`
+		// 		ChannelNameColor        string                 `yaml:"channelNameColor"`
+		// 		ChannelBNameColor       string                 `yaml:"channelBNameColor"`
+		// 		ZoneNameColor           string                 `yaml:"zoneNameColor"`
+		// 		ZoneBNameColor          string                 `yaml:"zoneBNameColor"`
+		// 		Language                string                 `yaml:"language"`
+		// 		DateFormat              string                 `yaml:"dateFormat"`
+		// 		Additional              map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"displaySettings"`
+		// 	AudioSettings struct {
+		// 		VoxDelay           string                 `yaml:"voxDelay"`
+		// 		VoxSource          string                 `yaml:"voxSource"`
+		// 		Recording          bool                   `yaml:"recording"`
+		// 		Enhance            bool                   `yaml:"enhance"`
+		// 		MuteDelay          string                 `yaml:"muteDelay"`
+		// 		MaxVolume          int                    `yaml:"maxVolume"`
+		// 		MaxHeadPhoneVolume int                    `yaml:"maxHeadPhoneVolume"`
+		// 		EnableFMMicGain    bool                   `yaml:"enableFMMicGain"`
+		// 		FmMicGain          int                    `yaml:"fmMicGain"`
+		// 		Additional         map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"audioSettings"`
+		// 	MenuSettings struct {
+		// 		Duration   string                 `yaml:"duration"`
+		// 		Separator  bool                   `yaml:"separator"`
+		// 		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"menuSettings"`
+		// 	AutoRepeaterSettings struct {
+		// 		DirectionA string                 `yaml:"directionA"`
+		// 		DirectionB string                 `yaml:"directionB"`
+		// 		VhfMin     string                 `yaml:"vhfMin"`
+		// 		VhfMax     string                 `yaml:"vhfMax"`
+		// 		UhfMin     string                 `yaml:"uhfMin"`
+		// 		UhfMax     string                 `yaml:"uhfMax"`
+		// 		Vhf2Min    string                 `yaml:"vhf2Min"`
+		// 		Vhf2Max    string                 `yaml:"vhf2Max"`
+		// 		Uhf2Min    string                 `yaml:"uhf2Min"`
+		// 		Uhf2Max    string                 `yaml:"uhf2Max"`
+		// 		Offsets    []interface{}          `yaml:"offsets"`
+		// 		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"autoRepeaterSettings"`
+		// 	DmrSettings struct {
+		// 		GroupCallHangTime         string                 `yaml:"groupCallHangTime"`
+		// 		ManualGroupCallHangTime   string                 `yaml:"manualGroupCallHangTime"`
+		// 		PrivateCallHangTime       string                 `yaml:"privateCallHangTime"`
+		// 		ManualPrivateCallHangTime string                 `yaml:"manualPrivateCallHangTime"`
+		// 		PreWaveDelay              int                    `yaml:"preWaveDelay"`
+		// 		WakeHeadPeriod            int                    `yaml:"wakeHeadPeriod"`
+		// 		FilterOwnID               bool                   `yaml:"filterOwnID"`
+		// 		MonitorSlotMatch          string                 `yaml:"monitorSlotMatch"`
+		// 		MonitorColorCodeMatch     bool                   `yaml:"monitorColorCodeMatch"`
+		// 		MonitorIDMatch            bool                   `yaml:"monitorIDMatch"`
+		// 		MonitorTimeSlotHold       bool                   `yaml:"monitorTimeSlotHold"`
+		// 		SmsFormat                 string                 `yaml:"smsFormat"`
+		// 		SendTalkerAlias           bool                   `yaml:"sendTalkerAlias"`
+		// 		TalkerAliasSource         string                 `yaml:"talkerAliasSource"`
+		// 		TalkerAliasEncoding       string                 `yaml:"talkerAliasEncoding"`
+		// 		Encryption                string                 `yaml:"encryption"`
+		// 		Additional                map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"dmrSettings"`
+		// 	GpsSettings struct {
+		// 		Units          string                 `yaml:"units"`
+		// 		TimeZone       string                 `yaml:"timeZone"`
+		// 		ReportPosition bool                   `yaml:"reportPosition"`
+		// 		UpdatePeriod   string                 `yaml:"updatePeriod"`
+		// 		Mode           string                 `yaml:"mode"`
+		// 		Additional     map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"gpsSettings"`
+		// 	RoamingSettings struct {
+		// 		AutoRoam          bool                   `yaml:"autoRoam"`
+		// 		AutoRoamPeriod    string                 `yaml:"autoRoamPeriod"`
+		// 		AutoRoamDelay     int                    `yaml:"autoRoamDelay"`
+		// 		RoamStart         string                 `yaml:"roamStart"`
+		// 		RoamReturn        string                 `yaml:"roamReturn"`
+		// 		RangeCheck        bool                   `yaml:"rangeCheck"`
+		// 		CheckInterval     string                 `yaml:"checkInterval"`
+		// 		RetryCount        int                    `yaml:"retryCount"`
+		// 		OutOfRangeAlert   string                 `yaml:"outOfRangeAlert"`
+		// 		Notification      bool                   `yaml:"notification"`
+		// 		NotificationCount int                    `yaml:"notificationCount"`
+		// 		GpsRoaming        bool                   `yaml:"gpsRoaming"`
+		// 		Additional        map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"roamingSettings"`
+		// 	BluetoothSettings struct {
+		// 		PttLatch      bool                   `yaml:"pttLatch"`
+		// 		PttSleepTimer int                    `yaml:"pttSleepTimer"`
+		// 		Additional    map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"bluetoothSettings"`
+		// 	SimplexRepeaterSettings struct {
+		// 		Enabled    bool                   `yaml:"enabled"`
+		// 		Monitor    bool                   `yaml:"monitor"`
+		// 		TimeSlot   string                 `yaml:"timeSlot"`
+		// 		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"simplexRepeaterSettings"`
+		// 	Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// } `yaml:"anytone,omitempty"`
+		// DefaultID  string                 `yaml:"defaultID,omitempty"`
 		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
 	} `yaml:"settings"`
 	RadioIDs []struct {
@@ -247,38 +247,38 @@ type Codeplug struct {
 	Channels    []*Channel   `yaml:"channels"`
 	Zones       []*Zone      `yaml:"zones"`
 	Positioning []struct {
-		Aprs struct {
-			ID      string `yaml:"id"`
-			Name    string `yaml:"name"`
-			Period  int    `yaml:"period"`
-			Icon    string `yaml:"icon"`
-			Message string `yaml:"message"`
-			Anytone struct {
-				TxDelay        string `yaml:"txDelay"`
-				PreWaveDelay   string `yaml:"preWaveDelay"`
-				PassAll        bool   `yaml:"passAll"`
-				ReportPosition bool   `yaml:"reportPosition"`
-				ReportMicE     bool   `yaml:"reportMicE"`
-				ReportObject   bool   `yaml:"reportObject"`
-				ReportItem     bool   `yaml:"reportItem"`
-				ReportMessage  bool   `yaml:"reportMessage"`
-				ReportWeather  bool   `yaml:"reportWeather"`
-				ReportNMEA     bool   `yaml:"reportNMEA"`
-				ReportStatus   bool   `yaml:"reportStatus"`
-				ReportOther    bool   `yaml:"reportOther"`
-				Frequencies    []struct {
-					ID         string                 `yaml:"id"`
-					Name       string                 `yaml:"name"`
-					Frequency  string                 `yaml:"frequency"`
-					Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-				} `yaml:"frequencies"`
-				Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-			} `yaml:"anytone"`
-			Destination string                 `yaml:"destination"`
-			Source      string                 `yaml:"source"`
-			Path        []string               `yaml:"path,flow"`
-			Additional  map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
-		} `yaml:"aprs"`
+		// Aprs struct {
+		// 	ID      string `yaml:"id"`
+		// 	Name    string `yaml:"name"`
+		// 	Period  int    `yaml:"period"`
+		// 	Icon    string `yaml:"icon"`
+		// 	Message string `yaml:"message"`
+		// 	Anytone struct {
+		// 		TxDelay        string `yaml:"txDelay"`
+		// 		PreWaveDelay   string `yaml:"preWaveDelay"`
+		// 		PassAll        bool   `yaml:"passAll"`
+		// 		ReportPosition bool   `yaml:"reportPosition"`
+		// 		ReportMicE     bool   `yaml:"reportMicE"`
+		// 		ReportObject   bool   `yaml:"reportObject"`
+		// 		ReportItem     bool   `yaml:"reportItem"`
+		// 		ReportMessage  bool   `yaml:"reportMessage"`
+		// 		ReportWeather  bool   `yaml:"reportWeather"`
+		// 		ReportNMEA     bool   `yaml:"reportNMEA"`
+		// 		ReportStatus   bool   `yaml:"reportStatus"`
+		// 		ReportOther    bool   `yaml:"reportOther"`
+		// 		Frequencies    []struct {
+		// 			ID         string                 `yaml:"id"`
+		// 			Name       string                 `yaml:"name"`
+		// 			Frequency  string                 `yaml:"frequency"`
+		// 			Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 		} `yaml:"frequencies"`
+		// 		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// 	} `yaml:"anytone"`
+		// 	Destination string                 `yaml:"destination"`
+		// 	Source      string                 `yaml:"source"`
+		// 	Path        []string               `yaml:"path,flow"`
+		// 	Additional  map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// } `yaml:"aprs"`
 		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
 	} `yaml:"positioning,omitempty"`
 	RoamingChannels []struct {
@@ -327,18 +327,18 @@ type Digital struct {
 	GroupList   string         `yaml:"groupList"`
 	Contact     string         `yaml:"contact"`
 	Anytone     struct {
-		Talkaround          bool                   `yaml:"talkaround"`
-		FrequencyCorrection int                    `yaml:"frequencyCorrection"`
-		HandsFree           bool                   `yaml:"handsFree"`
-		CallConfirm         bool                   `yaml:"callConfirm"`
-		Sms                 bool                   `yaml:"sms"`
-		SmsConfirm          bool                   `yaml:"smsConfirm"`
-		DataACK             bool                   `yaml:"dataACK"`
-		SimplexTDMA         bool                   `yaml:"simplexTDMA"`
-		AdaptiveTDMA        bool                   `yaml:"adaptiveTDMA"`
-		LoneWorker          bool                   `yaml:"loneWorker"`
-		ThroughMode         bool                   `yaml:"throughMode"`
-		Additional          map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
+		// Talkaround          bool                   `yaml:"talkaround"`
+		// FrequencyCorrection int                    `yaml:"frequencyCorrection"`
+		// HandsFree           bool                   `yaml:"handsFree"`
+		// CallConfirm         bool                   `yaml:"callConfirm"`
+		// Sms                 bool                   `yaml:"sms"`
+		// SmsConfirm          bool                   `yaml:"smsConfirm"`
+		// DataACK             bool                   `yaml:"dataACK"`
+		// SimplexTDMA         bool                   `yaml:"simplexTDMA"`
+		// AdaptiveTDMA        bool                   `yaml:"adaptiveTDMA"`
+		// LoneWorker          bool                   `yaml:"loneWorker"`
+		// ThroughMode         bool                   `yaml:"throughMode"`
+		Additional map[string]interface{} `yaml:",inline"` // Any new keys will show up here to be roundtripped
 	} `yaml:"anytone"`
 	Power      DefaultableString      `yaml:"power"`
 	Timeout    DefaultableInt         `yaml:"timeout"`

--- a/dmrfill.go
+++ b/dmrfill.go
@@ -88,7 +88,6 @@ var (
 	nameLength         int
 	open               bool
 	onAir              bool
-	tgSource           string
 	location           string
 	radius             float64
 	radiusUnits        string
@@ -110,11 +109,6 @@ func init() {
 	flag.IntVar(&nameLength, "name_lim", 16, "Length limit for generated names")
 	flag.BoolVar(&open, "open", true, "Only include open repeaters")
 	flag.BoolVar(&onAir, "on_air", true, "Only include on-air repeaters")
-	flag.StringVar(&tgSource, "tg_source", "most",
-		`One of ('most' 'rfinder' 'details').
-RadioID has two fields that may contain talkgroup info, 'details' and 'rfinder'.
-By default dmrfill uses the data from whichever field has the most talkgroups defined.
-Selecting 'rfinder' or 'details' uses the named field.`)
 	flag.StringVar(&location, "loc", "", "Center location for proximity search, e.g. 'Bangor, ME', 'München'")
 	flag.Float64Var(&radius, "radius", 25, "Radius for proximity search")
 	flag.StringVar(&radiusUnits, "units", "miles", "Distance units for proximity search, one of ('miles' 'km')")
@@ -455,13 +449,6 @@ func parseArguments() (io.ReadCloser, io.WriteCloser) {
 		// good
 	default:
 		fatal("power must be one of (Min Low Mid High Max)")
-	}
-
-	switch tgSource {
-	case "most", "rfinder", "details":
-		// good
-	default:
-		fatal("tg_source must be one of (most rfinder details)")
 	}
 
 	if radius <= 0.0 {


### PR DESCRIPTION
By removing attributes we're not using from the codeplug struct, we're less sensitive to YAML changes in QDMR, because undefined attributes are round-tripped.

Also RadioID removed the `rfinder` attribute from their response. Before, we got both what the repeater owner had entered and what RFinder provided for talkgroups. Now we only get whichever the repeater owner has chosen, so there's no need for the `-tg_source` option to choose which to use.